### PR TITLE
Fix formatting string in get_record method

### DIFF
--- a/sync/client.py
+++ b/sync/client.py
@@ -149,8 +149,8 @@ class SyncClient(object):
     def get_record(self, collection, record_id):
         """Returns the BSO in the collection corresponding to the requested id.
         """
-        return self._request('get', '/storage/%s/%s' % collection.lower(),
-                             record_id)
+        return self._request('get', '/storage/%s/%s' % (collection.lower(),
+                             record_id))
 
     def put_record(self, collection, record, if_unmodified_since=None):
         """


### PR DESCRIPTION
Otherwise `, record_id` is interpreted as an argument of `self._request` instead of for the string formatting.
