### PR TITLE
When having a HTTP 304 Not Modified from Firefox Sync, pass it along.

### DIFF
--- a/syncclient/client.py
+++ b/syncclient/client.py
@@ -109,6 +109,15 @@ class SyncClient(object):
         url = self.api_endpoint.rstrip('/') + '/' + url.lstrip('/')
         self.raw_resp = requests.request(method, url, auth=self.auth, **kwargs)
         self.raw_resp.raise_for_status()
+
+        # Also handle 301, 302, and 304
+        if 300 <= self.raw_resp.status_code < 400:
+            http_error_msg = '%s Client Error: %s for url: %s' % (
+                self.raw_resp.status_code,
+                self.raw_resp.reason,
+                self.raw_resp.url)
+            raise requests.exceptions.HTTPError(http_error_msg,
+                                                response=self.raw_resp)
         return self.raw_resp.json()
 
     def info_collections(self, **kwargs):

--- a/syncclient/client.py
+++ b/syncclient/client.py
@@ -110,8 +110,7 @@ class SyncClient(object):
         self.raw_resp = requests.request(method, url, auth=self.auth, **kwargs)
         self.raw_resp.raise_for_status()
 
-        # Also handle 301, 302, and 304
-        if 300 <= self.raw_resp.status_code < 400:
+        if self.raw_resp.status_code == 304:
             http_error_msg = '%s Client Error: %s for url: %s' % (
                 self.raw_resp.status_code,
                 self.raw_resp.reason,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import mock
 from hashlib import sha256
+from requests.exceptions import HTTPError
 
 from syncclient.client import (
     TokenserverClient, SyncClient, SyncClientError, TOKENSERVER_URL,
@@ -393,6 +394,28 @@ class ClientHTTPCallsTest(unittest.TestCase):
         # For now, this does nothing.
         records = [{'id': idx, 'foo': 'foo'} for idx in range(1, 10)]
         self.client.post_records("myCollection", records)
+
+
+class HandleSyncRequestsResponseTest(unittest.TestCase):
+    def setUp(self):
+        super(HandleSyncRequestsResponseTest, self).setUp()
+        self.client = SyncClient(
+            hashalg=mock.sentinel.hashalg,
+            id=mock.sentinel.id,
+            key=mock.sentinel.key,
+            uid=mock.sentinel.uid,
+            api_endpoint="http://sync.services.mozilla.com/"
+        )
+
+    def test_get_record_can_handle_empty_response(self):
+        with mock.patch("syncclient.client.requests.request") as request:
+            response = mock.MagicMock()
+            response.status_code = 304
+            response.response = "Not Modified"
+            response.url = "http://www.example.com/"
+            request.return_value = response
+            self.assertRaises(HTTPError,
+                              self.client.get_record, 'myCollection', 1234)
 
 
 class EncodeHeaderTest(unittest.TestCase):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -126,6 +126,7 @@ class ClientRequestIssuanceTest(unittest.TestCase):
         # Mock requests to avoid issuance of requests when we start the client.
         patched = patch(self, 'syncclient.client.requests')
         self.requests = patched[0].request
+        self.requests.return_value.status_code = 200
 
     def _get_client(self, api_endpoint='http://example.org/'):
         client = SyncClient("bid_assertion", "client_state")


### PR DESCRIPTION
```
 File "syncclient/client.py", line 112, in _request
    return self.raw_resp.json()
  File "requests/models.py", line 819, in json
    return json.loads(self.text, **kwargs)
ValueError: Expected object or value; uid=None; errno=None; agent=HTTPie/0.9.2; authn_type=None
```
