### PR TITLE
Attempt to fix the put_record method.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ REQUIREMENTS = [
     'PyFxA',
     'requests',
     'requests-hawk',
+    'six',
 ]
 
 setup(name='syncclient',

--- a/syncclient/client.py
+++ b/syncclient/client.py
@@ -253,6 +253,7 @@ class SyncClient(object):
         Note that the server may impose a limit on the amount of data
         submitted for storage in a single BSO.
         """
+        # XXX: Workaround until request-hawk supports the json parameter. (#17)
         if isinstance(record, six.string_types):
             record = json.loads(record)
         record = record.copy()

--- a/syncclient/client.py
+++ b/syncclient/client.py
@@ -37,7 +37,7 @@ def get_browserid_assertion(login, password, fxa_server_url=FXA_SERVER_URL,
     session = client.login(login, password, keys=True)
     bid_assertion = session.get_identity_assertion(tokenserver_url)
     _, keyB = session.fetch_keys()
-    if isinstance(keyB, six.text_type):
+    if isinstance(keyB, six.text_type):  # pragma: no cover
         keyB = keyB.encode('utf-8')
     return bid_assertion, hexlify(sha256(keyB).digest()[0:16])
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -375,16 +375,26 @@ class ClientHTTPCallsTest(unittest.TestCase):
         self.client.put_record('myCollection', record)
         self.client._request.assert_called_with(
             'put', '/storage/mycollection/1234',
-            json={'foo': 'bar'})
+            data='{"foo": "bar"}',
+            headers={'Content-Type': 'application/json; charset=utf-8'})
+
+    def test_put_record_handle_json_string_parameter(self):
+        record = '{"id": 1234, "foo": "bar"}'
+        self.client.put_record('myCollection', record)
+        self.client._request.assert_called_with(
+            'put', '/storage/mycollection/1234',
+            data='{"foo": "bar"}',
+            headers={'Content-Type': 'application/json; charset=utf-8'})
 
     def test_put_record_can_receive_requests_parameters(self):
         record = {'id': 1234, 'foo': 'bar'}
         self.client.put_record('myCollection', record,
-                               headers=mock.sentinel.headers)
+                               headers={'Sentinel': 'true'})
         self.client._request.assert_called_with(
             'put', '/storage/mycollection/1234',
-            json={'foo': 'bar'},
-            headers=mock.sentinel.headers)
+            data='{"foo": "bar"}',
+            headers={'Content-Type': 'application/json; charset=utf-8',
+                     'Sentinel': 'true'})
 
     def test_put_record_doesnt_modify_the_passed_object(self):
         record = {'id': 1234, 'foo': 'bar'}


### PR DESCRIPTION
`requests-hawk` doesn't handle the json parameter.
For now we are using the old way of doing JSON requests.
